### PR TITLE
create release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: |
+          The version to build and upload to GH releases.
+          The release will be marked as a draft.
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - run: ldd --version # print glibc version
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: install dependencies
+        run: sudo apt-get install -y libevdev-dev
+
+      - name: Build
+        run: cargo build --release
+
+      - name: package
+        run: |
+          set -x
+          ls -la target/release
+          mkdir -p _package/usr/bin
+          mkdir -p _package/usr/share/man/man1
+          strip target/release/map2 -o _package/usr/bin/map2
+          target/release/man-gen | gzip -c > _package/usr/share/man/man1/map2.1.gz
+          tar -czvf "map2-$TAG-x86_64.tar.gz" -C _package .
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: map2-${{ github.event.inputs.tag }}-x86_64.tar.gz
+          name: map2-${{ github.event.inputs.tag }}-x86_64
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-20.04
+
+    permissions: write-all
+
+    needs:
+      - build
+
+    steps:
+
+      # needed by `draft release` below
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: map2-${{ github.event.inputs.tag }}-x86_64
+
+      - name: draft release
+        run: |
+          gh release create "$TAG" --draft --title "$TAG" \
+            --target "$(git rev-parse --verify HEAD)" \
+            --generate-notes --verify-tag \
+            "map2-$TAG-x86_64.tar.gz"
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Wayland support is planned but probably won't be added for some time.
 
 For details check the [documentation](#documentation).
 
+<ins>**The next major release of map2 is currently in preview on the [python
+branch](https://github.com/shiro/map2/tree/python)**</ins>.  
+There's almost no documentation yet, the API will likely change and things
+might break, but if you want to test out the future release and provide
+feedback you can check it out. The current version of map2 will continue to
+exist [in another repo](https://github.com/shiro/map2-legacy) but won't receive
+any new features.
+
 # Examples
 
 Map2 is a very flexible scripting language that can utilize logic control


### PR DESCRIPTION
Adds a GitHub workflow action that produces structurally identical output to the current release uploads.

It's manually triggered via `workflow_dispatch`. I.e. used like this:
1. Create and push a version tag.
2. Go to https://github.com/shiro/map2/actions/workflows/release.yml and run the pipeline
    ![image](https://user-images.githubusercontent.com/18194808/233921123-5cb05b7a-37a0-449d-990b-14b21e3896b6.png)
3. When it finished successfully it will have created a draft release in the GitHub releases section.
4. Review / edit release notes and publish release.

glibc version: 2.31

Fixes #1